### PR TITLE
Consolidate badge width calculation and simplify kbd insert functions

### DIFF
--- a/src/content/commands/emoji/command.test.ts
+++ b/src/content/commands/emoji/command.test.ts
@@ -18,6 +18,7 @@ vi.mock("../../picker/index.ts", () => ({
   },
   getCommandCache: vi.fn().mockReturnValue(null),
   setCommandCache: vi.fn(),
+  calculateBadgeWidth: (text: string) => text.length * 8 + 16,
 }))
 
 // Mock storage

--- a/src/content/commands/emoji/command.ts
+++ b/src/content/commands/emoji/command.ts
@@ -12,6 +12,7 @@ import {
   getCommandCache,
   setCommandCache,
   insertTextAtCursor,
+  calculateBadgeWidth,
 } from "../../picker/index.ts"
 import type { PickerItem } from "../../types.ts"
 import {
@@ -51,13 +52,6 @@ function getCategoryColor(category: EmojiCategory): string {
     default:
       return "#64748b"
   }
-}
-
-/** Calculate badge width based on text length (character width ~5px + padding 12px) */
-function calculateBadgeWidth(text: string): number {
-  const charWidth = 5
-  const padding = 12
-  return text.length * charWidth + padding
 }
 
 /** Create a tile for an emoji */

--- a/src/content/commands/font/command.test.ts
+++ b/src/content/commands/font/command.test.ts
@@ -15,6 +15,7 @@ vi.mock("../../picker/index.ts", () => ({
     currentItems: [],
     selectedIndex: 0,
   },
+  calculateBadgeWidth: (text: string) => text.length * 8 + 16,
 }))
 
 describe("font command", () => {

--- a/src/content/commands/font/command.ts
+++ b/src/content/commands/font/command.ts
@@ -7,7 +7,7 @@
 
 import { escapeForSvg } from "../../../utils/svg.ts"
 import { registerCommand, type CommandSpec } from "../registry.ts"
-import { renderGrid, state, insertTextAtCursor } from "../../picker/index.ts"
+import { renderGrid, state, insertTextAtCursor, calculateBadgeWidth } from "../../picker/index.ts"
 import type { PickerItem } from "../../types.ts"
 
 /** Font option types */
@@ -180,7 +180,7 @@ function makeFontTile(option: FontOption): PickerItem {
   <rect x="12" y="12" width="216" height="152" rx="14" fill="#ffffff" fill-opacity="0.65" stroke="#0f172a" stroke-opacity="0.10"/>
   
   <!-- Category badge -->
-  <rect x="20" y="20" width="${CATEGORY_LABELS[option.category].length * 8 + 16}" height="24" rx="6" fill="${categoryColor}" fill-opacity="0.15"/>
+  <rect x="20" y="20" width="${calculateBadgeWidth(CATEGORY_LABELS[option.category])}" height="24" rx="6" fill="${categoryColor}" fill-opacity="0.15"/>
   <text x="28" y="37" font-family="system-ui, -apple-system, Segoe UI, Roboto, sans-serif" font-size="12" font-weight="600" fill="${categoryColor}">${escapeForSvg(CATEGORY_LABELS[option.category])}</text>
   
   <!-- Preview text -->

--- a/src/content/commands/kbd/command.test.ts
+++ b/src/content/commands/kbd/command.test.ts
@@ -24,6 +24,7 @@ vi.mock("../../picker/index.ts", () => ({
     currentItems: [],
     selectedIndex: 0,
   },
+  calculateBadgeWidth: (text: string) => text.length * 8 + 16,
 }))
 
 describe("kbd command", () => {

--- a/src/content/commands/kbd/command.ts
+++ b/src/content/commands/kbd/command.ts
@@ -11,7 +11,7 @@
 
 import { escapeForSvg } from "../../../utils/svg.ts"
 import { registerCommand, type CommandSpec } from "../registry.ts"
-import { renderGrid, state, insertTextAtCursor } from "../../picker/index.ts"
+import { renderGrid, state, insertTextAtCursor, calculateBadgeWidth } from "../../picker/index.ts"
 import type { PickerItem } from "../../types.ts"
 
 /** Key aliases for different platforms */
@@ -216,7 +216,7 @@ function makeKbdTile(shortcut: KeyboardShortcut): PickerItem {
   <rect x="12" y="12" width="216" height="152" rx="14" fill="#ffffff" fill-opacity="0.65" stroke="#0f172a" stroke-opacity="0.10"/>
   
   <!-- Category badge -->
-  <rect x="20" y="20" width="${CATEGORY_LABELS[shortcut.category].length * 8 + 16}" height="24" rx="6" fill="${categoryColor}" fill-opacity="0.15"/>
+  <rect x="20" y="20" width="${calculateBadgeWidth(CATEGORY_LABELS[shortcut.category])}" height="24" rx="6" fill="${categoryColor}" fill-opacity="0.15"/>
   <text x="28" y="37" font-family="system-ui, -apple-system, Segoe UI, Roboto, sans-serif" font-size="12" font-weight="600" fill="${categoryColor}">${escapeForSvg(CATEGORY_LABELS[shortcut.category])}</text>
   
   <!-- Key display -->
@@ -264,11 +264,6 @@ function getSortedShortcuts(shortcuts: KeyboardShortcut[]): KeyboardShortcut[] {
 /** Insert formatted keyboard shortcut into the textarea */
 function insertKbdMarkdown(shortcut: KeyboardShortcut): void {
   insertTextAtCursor(inputToKbdHtml(shortcut.input) + " ")
-}
-
-/** Insert custom keyboard shortcut from user input */
-function insertCustomKbd(input: string): void {
-  insertTextAtCursor(inputToKbdHtml(input) + " ")
 }
 
 /** Get category suggestions */
@@ -348,12 +343,7 @@ const kbdCommand: CommandSpec = {
 
   onSelect: (it: PickerItem) => {
     if (!it) return
-    const shortcut = it.data as KeyboardShortcut
-    if (shortcut.id === "custom-input") {
-      insertCustomKbd(shortcut.input)
-    } else {
-      insertKbdMarkdown(shortcut)
-    }
+    insertKbdMarkdown(it.data as KeyboardShortcut)
   },
 
   noResultsMessage: "No matching shortcuts. Type your own like: ctrl+p, cmd+shift+s",

--- a/src/content/commands/mermaid/command.test.ts
+++ b/src/content/commands/mermaid/command.test.ts
@@ -16,6 +16,7 @@ vi.mock("../../picker/index.ts", () => ({
     currentItems: [],
     selectedIndex: 0,
   },
+  calculateBadgeWidth: (text: string) => text.length * 8 + 16,
 }))
 
 describe("mermaid command", () => {

--- a/src/content/commands/mermaid/command.ts
+++ b/src/content/commands/mermaid/command.ts
@@ -7,7 +7,7 @@
 
 import { escapeForSvg } from "../../../utils/svg.ts"
 import { registerCommand, type CommandSpec } from "../registry.ts"
-import { renderGrid, state, insertTextAtCursor } from "../../picker/index.ts"
+import { renderGrid, state, insertTextAtCursor, calculateBadgeWidth } from "../../picker/index.ts"
 import type { PickerItem } from "../../types.ts"
 import {
   DIAGRAM_TEMPLATES,
@@ -87,7 +87,7 @@ function makeDiagramTile(template: DiagramTemplate): PickerItem {
   <rect x="12" y="12" width="216" height="152" rx="14" fill="#ffffff" fill-opacity="0.65" stroke="#0f172a" stroke-opacity="0.10"/>
   
   <!-- Category badge -->
-  <rect x="20" y="20" width="${DIAGRAM_CATEGORY_LABELS[template.category].length * 8 + 16}" height="24" rx="6" fill="${categoryColor}" fill-opacity="0.15"/>
+  <rect x="20" y="20" width="${calculateBadgeWidth(DIAGRAM_CATEGORY_LABELS[template.category])}" height="24" rx="6" fill="${categoryColor}" fill-opacity="0.15"/>
   <text x="28" y="37" font-family="system-ui, -apple-system, Segoe UI, Roboto, sans-serif" font-size="12" font-weight="600" fill="${categoryColor}">${escapeForSvg(DIAGRAM_CATEGORY_LABELS[template.category])}</text>
   
   <!-- Diagram icon -->

--- a/src/content/commands/now/command.test.ts
+++ b/src/content/commands/now/command.test.ts
@@ -16,6 +16,7 @@ vi.mock("../../picker/index.ts", () => ({
     currentItems: [],
     selectedIndex: 0,
   },
+  calculateBadgeWidth: (text: string) => text.length * 8 + 16,
 }))
 
 describe("now command", () => {

--- a/src/content/commands/now/command.ts
+++ b/src/content/commands/now/command.ts
@@ -7,7 +7,7 @@
 
 import { escapeForSvg } from "../../../utils/svg.ts"
 import { registerCommand, type CommandSpec } from "../registry.ts"
-import { renderGrid, state, insertTextAtCursor } from "../../picker/index.ts"
+import { renderGrid, state, insertTextAtCursor, calculateBadgeWidth } from "../../picker/index.ts"
 import type { PickerItem } from "../../types.ts"
 
 /** Date format types */
@@ -196,8 +196,6 @@ function getFormatCategory(format: DateFormat): string {
 /** SVG layout constants for tile rendering */
 const TILE_PREVIEW_MAX_LENGTH = 28
 const TILE_PREVIEW_TRUNCATE_AT = 25
-const BADGE_CHAR_WIDTH = 8
-const BADGE_PADDING = 16
 
 /** Create a tile for a date option */
 function makeDateTile(option: DateOption, previewDate: Date): PickerItem {
@@ -211,7 +209,7 @@ function makeDateTile(option: DateOption, previewDate: Date): PickerItem {
       ? previewValue.slice(0, TILE_PREVIEW_TRUNCATE_AT) + "..."
       : previewValue
 
-  const badgeWidth = categoryLabel.length * BADGE_CHAR_WIDTH + BADGE_PADDING
+  const badgeWidth = calculateBadgeWidth(categoryLabel)
 
   const svg = `<?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" width="240" height="176" viewBox="0 0 240 176">

--- a/src/content/picker/styles.ts
+++ b/src/content/picker/styles.ts
@@ -4,6 +4,18 @@
 
 import { isDarkMode, fontSystemUi, fontSansSerif, tokenLinearGradient } from "../../utils/theme.ts"
 
+/** SVG badge layout constants */
+export const BADGE_CHAR_WIDTH = 8
+export const BADGE_PADDING = 16
+
+/**
+ * Calculate badge width based on text length.
+ * Uses fixed character width approximation for system fonts.
+ */
+export function calculateBadgeWidth(text: string): number {
+  return text.length * BADGE_CHAR_WIDTH + BADGE_PADDING
+}
+
 export type StyleConfig = {
   dark: boolean
 }


### PR DESCRIPTION
- Extract calculateBadgeWidth utility to picker/styles.ts for consistent badge sizing across all commands (font, kbd, mermaid, now, emoji)
- Remove duplicate insertCustomKbd function in kbd command, using single insertKbdMarkdown for both common and custom shortcuts
- Update test mocks to include the new calculateBadgeWidth function