### PR TITLE
Add markdown preview button for demo page textarea

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -465,8 +465,12 @@ Examples:
         // Store mermaid blocks to render after HTML is inserted
         let mermaidBlocks = [];
 
-        renderer.code = function(code, language) {
-          if (language === "mermaid") {
+        // marked v5+ passes an object { text, lang }, older versions pass (code, language)
+        renderer.code = function(codeOrObj, language) {
+          const code = typeof codeOrObj === "object" ? codeOrObj.text : codeOrObj;
+          const lang = typeof codeOrObj === "object" ? codeOrObj.lang : language;
+
+          if (lang === "mermaid") {
             const id = "mermaid-" + mermaidBlocks.length;
             mermaidBlocks.push({ id, code });
             return '<div class="mermaid" id="' + id + '"></div>';


### PR DESCRIPTION
Implements issue #56 - adds Write/Preview tabs to the demo page textarea,
similar to GitHub's native comment UI.

Features:
- Tab bar with Write and Preview buttons
- Click Preview to see rendered markdown
- Click Write to return to editing
- Basic markdown renderer supporting headers, bold, italic, code, links,
  images, lists, blockquotes, and more
- Styled to match GitHub's dark theme