### PR TITLE
Add popover close button and unified settings panel

### DIFF
--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -34,6 +34,9 @@ import "./commands/now/index.ts"
 import "./commands/kbd/index.ts"
 import "./commands/link/index.ts"
 
+// Import shared options modules to register them for the settings panel
+import "../options/github/index.ts"
+
 /**
  * Resolve the command name and query from parsed slash command.
  * If the parsed command name is not a registered command and has no query,

--- a/src/content/picker/components/Picker.tsx
+++ b/src/content/picker/components/Picker.tsx
@@ -34,6 +34,8 @@ export type PickerProps = {
   onHover: (index: number) => void
   onSuggestPick: (term: string) => void
   onSettingsClick: () => void
+  onCloseClick: () => void
+  onSettingsBackClick: () => void
   onSetupComplete: () => void
   position: Position
 }
@@ -49,6 +51,8 @@ export function Picker({
   onHover,
   onSuggestPick,
   onSettingsClick,
+  onCloseClick,
+  onSettingsBackClick,
   onSetupComplete,
   position,
 }: PickerProps) {
@@ -119,7 +123,7 @@ export function Picker({
           />
         )
       case "settings":
-        return <SettingsPanel />
+        return <SettingsPanel onBackClick={onSettingsBackClick} />
       case "setup":
         return (
           <div
@@ -154,7 +158,12 @@ export function Picker({
         top: `${position.top}px`,
       }}
     >
-      <PickerHeader title={title} subtitle={subtitle} onSettingsClick={onSettingsClick} />
+      <PickerHeader
+        title={title}
+        subtitle={subtitle}
+        onSettingsClick={onSettingsClick}
+        onCloseClick={onCloseClick}
+      />
       <PickerHints />
       {renderBody()}
       <PickerFooter />

--- a/src/content/picker/components/PickerHeader.tsx
+++ b/src/content/picker/components/PickerHeader.tsx
@@ -10,6 +10,7 @@ export type PickerHeaderProps = {
   title: string
   subtitle: string
   onSettingsClick: () => void
+  onCloseClick: () => void
 }
 
 const SettingsIcon = () => (
@@ -19,10 +20,33 @@ const SettingsIcon = () => (
   </svg>
 )
 
-export function PickerHeader({ title, subtitle, onSettingsClick }: PickerHeaderProps) {
-  const [isHovered, setIsHovered] = React.useState(false)
+const CloseIcon = () => (
+  <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+    <path d="M3.72 3.72a.75.75 0 0 1 1.06 0L8 6.94l3.22-3.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L9.06 8l3.22 3.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L8 9.06l-3.22 3.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L6.94 8 3.72 4.78a.75.75 0 0 1 0-1.06Z" />
+  </svg>
+)
+
+export function PickerHeader({
+  title,
+  subtitle,
+  onSettingsClick,
+  onCloseClick,
+}: PickerHeaderProps) {
+  const [hoveredBtn, setHoveredBtn] = React.useState<"settings" | "close" | null>(null)
   const dark = isDarkMode()
   const badgeStyles = getBadgeStyles()
+
+  const iconButtonStyle = (btn: "settings" | "close"): React.CSSProperties => ({
+    background: "none",
+    border: "none",
+    cursor: "pointer",
+    padding: "4px",
+    opacity: hoveredBtn === btn ? 1 : 0.62,
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    color: dark ? "rgba(255,255,255,0.92)" : "rgba(0,0,0,0.88)",
+  })
 
   return (
     <div
@@ -56,21 +80,22 @@ export function PickerHeader({ title, subtitle, onSettingsClick }: PickerHeaderP
           data-settings-btn="true"
           title="Settings"
           onClick={onSettingsClick}
-          onMouseEnter={() => setIsHovered(true)}
-          onMouseLeave={() => setIsHovered(false)}
-          style={{
-            background: "none",
-            border: "none",
-            cursor: "pointer",
-            padding: "4px",
-            opacity: isHovered ? 1 : 0.62,
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            color: dark ? "rgba(255,255,255,0.92)" : "rgba(0,0,0,0.88)",
-          }}
+          onMouseEnter={() => setHoveredBtn("settings")}
+          onMouseLeave={() => setHoveredBtn(null)}
+          style={iconButtonStyle("settings")}
         >
           <SettingsIcon />
+        </button>
+        <button
+          type="button"
+          data-settings-btn="true"
+          title="Close"
+          onClick={onCloseClick}
+          onMouseEnter={() => setHoveredBtn("close")}
+          onMouseLeave={() => setHoveredBtn(null)}
+          style={iconButtonStyle("close")}
+        >
+          <CloseIcon />
         </button>
       </div>
     </div>

--- a/src/content/picker/picker-react.tsx
+++ b/src/content/picker/picker-react.tsx
@@ -32,6 +32,9 @@ const reactState: ReactPickerState = {
   position: { left: 0, top: 0 },
 }
 
+// Store the view before switching to settings so we can restore it
+let viewBeforeSettings: PickerView | null = null
+
 // Callbacks for picker interactions
 let currentImgUrlFn: (item: PickerItem) => string = (item) => item.previewUrl
 let currentOnSelect: (item: PickerItem) => void = () => {}
@@ -71,8 +74,26 @@ function renderPicker(): void {
       },
       onSuggestPick: currentOnSuggestPick,
       onSettingsClick: () => {
+        // Store current view before switching to settings
+        if (reactState.view.type !== "settings") {
+          viewBeforeSettings = reactState.view
+        }
         state.showingSettings = true
         reactState.view = { type: "settings" }
+        renderPicker()
+      },
+      onCloseClick: () => {
+        hidePicker()
+      },
+      onSettingsBackClick: () => {
+        state.showingSettings = false
+        // Restore the previous view if available
+        if (viewBeforeSettings) {
+          reactState.view = viewBeforeSettings
+          viewBeforeSettings = null
+        } else {
+          reactState.view = { type: "loading" }
+        }
         renderPicker()
       },
       onSetupComplete: currentOnSetupComplete,
@@ -179,6 +200,7 @@ export function hidePicker(): void {
   if (!state.pickerEl) return
   reactState.visible = false
   reactState.view = { type: "loading" }
+  viewBeforeSettings = null
   renderPicker()
   resetPickerState()
 }


### PR DESCRIPTION
- Add close button (X icon) next to settings icon in picker header
- Add back button in settings panel to return to previous view
- Refactor settings panel to use shared options sections from registry
- Import GitHub options module in content script for settings panel