### PR TITLE
Fix main deployment cleanup by using keep_files: false

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -118,7 +118,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./gh-pages
-          keep_files: true
+          keep_files: false
 
       - name: Create GitHub Deployment (PR)
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
The keep_files: true option was preserving old main deployments on the remote gh-pages branch even after we deleted them locally. Since we checkout the entire gh-pages branch first (preserving PR deployments), we can safely use keep_files: false to ensure our local state (with old deployments removed) is pushed correctly.