### PR TITLE
Merge //link and //link ci into unified command with CI keywords

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -251,7 +251,7 @@ bun run test:e2e     # E2E tests
 
 - **Chrome Extension Context**: Code runs as a content script with access to Chrome APIs
 - **GitHub DOM**: The extension injects into GitHub's markdown textareas
-- **API Keys**: Some commands (e.g., `/giphy`, `/link ci`) require API keys stored via `chrome.storage.local`
+- **API Keys**: Some commands (e.g., `/giphy`, `/link artifact`) require API keys stored via `chrome.storage.local`
 - **Privacy**: No data is sent to external servers except necessary API calls (Giphy, GitHub)
 - **Theme Support**: Picker styling aligns with GitHub's native UI and supports light/dark themes
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -12,12 +12,12 @@ GitHub Slash Palette is a Chrome extension that adds slash commands to GitHub ma
 ### 1. Search Queries
 
 - **`/giphy`**: Your search text is sent to the Giphy API to fetch GIF results.
-- **`/link ci`**: Your GitHub token is used to fetch CI job and artifact data from the GitHub API for the current repository only.
+- **`/link artifact`**, **`/link job`**: Your GitHub token is used to fetch CI job and artifact data from the GitHub API for the current repository only.
 
 ### 2. API Keys and Tokens
 
 - **Giphy API Key**: If you enter a Giphy API key, it is stored locally in your browser so the extension can call the Giphy API on your behalf.
-- **GitHub Personal Access Token**: If you enter a GitHub token for `/link ci`, it is stored locally in your browser to authenticate with the GitHub API.
+- **GitHub Personal Access Token**: If you enter a GitHub token for `/link artifact` or `/link job`, it is stored locally in your browser to authenticate with the GitHub API.
 
 ### 3. Local Preferences
 
@@ -39,7 +39,7 @@ When you use `/giphy`, your search query (and your API key) is sent to Giphy to 
 
 ### GitHub
 
-When you use `/link ci`, your token is sent to GitHub's API (`api.github.com`) to fetch CI job and artifact data for the current repository.
+When you use `/link artifact` or `/link job`, your token is sent to GitHub's API (`api.github.com`) to fetch CI job and artifact data for the current repository.
 
 No other third-party services are contacted by the extension.
 
@@ -62,7 +62,7 @@ The extension does not use analytics, tracking pixels, advertising identifiers, 
 
 - **storage**: Used to save local settings, including API keys, tokens, and recently used items.
 - **Host permission `https://api.giphy.com`**: Used for `/giphy` search requests and GIF previews.
-- **Host permission `https://api.github.com`**: Used for `/link ci` to fetch CI job and artifact data.
+- **Host permission `https://api.github.com`**: Used for `/link artifact` and `/link job` to fetch CI job and artifact data.
 
 ## Contact
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ Try the extension without installing it. All deployments (main + PR previews): *
 - `//font` to style text with sizes, colors, and formatting
 - `//kbd` to format keyboard shortcuts
 - `//link` to insert markdown links with auto-generated titles
-- `//link ci` to link to CI jobs and artifacts (requires GitHub token)
+- `//link artifact` to link to CI artifacts (requires GitHub token)
+- `//link job` to link to CI jobs (requires GitHub token)
 - `//mention` for context-aware participant mentions
 - `//mermaid` to insert diagram templates
 - `//now` to insert formatted timestamps
@@ -207,10 +208,11 @@ registerCommand("mycommand", myCommand)
 
 Some features require a GitHub Personal Access Token (PAT):
 
-- `//link ci` - Link to CI jobs and artifacts
+- `//link artifact` - Link to CI artifacts
+- `//link job` - Link to CI jobs
 
 ### Option 1: In picker settings
-1. Type `//link ci` or click the settings gear
+1. Type `//link artifact` or click the settings gear
 2. Find **GitHub Token** section
 3. Paste your token and click **Save**
 

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -10,7 +10,8 @@ This folder contains end-user and developer documentation for each registered sl
 - [//font](font/README.md) – apply font styling (sizes, colors, styles) to text
 - [//kbd](kbd/README.md) – format keyboard shortcuts with `<kbd>` tags
 - [//link](link/README.md) – insert markdown links with auto-generated titles
-  - `//link ci` – link to CI jobs and artifacts (requires [GitHub token](../options/github/README.md))
+  - `//link artifact` – link to CI artifacts (requires [GitHub token](../options/github/README.md))
+  - `//link job` – link to CI jobs (requires [GitHub token](../options/github/README.md))
 - [//mention](mention/README.md) – context-aware mention autocomplete for participants
 - [//mermaid](mermaid/README.md) – insert Mermaid diagram templates
 - [//now](now/README.md) – insert formatted date and timestamps
@@ -19,4 +20,4 @@ This folder contains end-user and developer documentation for each registered sl
 
 Some commands require API keys or tokens:
 
-- [GitHub API Options](../options/github/README.md) – Personal Access Token for `//link ci` and other GitHub API features
+- [GitHub API Options](../options/github/README.md) – Personal Access Token for `//link artifact`, `//link job`, and other GitHub API features

--- a/docs/commands/link/README.md
+++ b/docs/commands/link/README.md
@@ -1,6 +1,6 @@
 # //link Command
 
-Insert markdown links with auto-generated titles.
+Insert markdown links with auto-generated titles and link to CI resources.
 
 ## Usage
 
@@ -8,7 +8,9 @@ Insert markdown links with auto-generated titles.
 //link                           – Opens the link picker with empty state
 //link example.com               – Prefills with URL, auto-generates title from domain
 //link example.com "My Title"    – Prefills URL and custom title
-//link https://example.com/path  – Works with full URLs
+//link artifact                  – Shows CI artifacts (requires GitHub token)
+//link job                       – Shows CI jobs (requires GitHub token)
+//link build                     – Searches CI resources for "build"
 ```
 
 ## Features
@@ -17,8 +19,9 @@ Insert markdown links with auto-generated titles.
 - **Custom titles**: Add a title in quotes after the URL to override the auto-generated title
 - **Protocol handling**: URLs without a protocol get `https://` added automatically
 - **Preview**: See a preview of the link before inserting
+- **CI integration**: Link to CI jobs and artifacts using keywords
 
-## Examples
+## URL Link Examples
 
 | Input | Output |
 |-------|--------|
@@ -36,22 +39,46 @@ Insert markdown links with auto-generated titles.
 
 ---
 
-# //link ci Subcommand
+# CI Resources (Jobs & Artifacts)
 
-Link to CI jobs and artifacts from the current repository.
+Link to CI jobs and artifacts from the current repository using CI keywords.
 
 ## Requirements
 
-This subcommand requires a GitHub Personal Access Token. See [GitHub API Options](../../options/github/README.md) for setup instructions.
+CI features require a GitHub Personal Access Token. See [GitHub API Options](../../options/github/README.md) for setup instructions.
 
-## Usage
+## CI Keywords
 
-```
-//link ci                        – Shows recent CI jobs and artifacts
-//link ci <query>                – Fuzzy search for matching jobs/artifacts
-//link ci e2e                    – Links to jobs containing "e2e"
-//link ci report                 – Links to artifacts containing "report"
-```
+The following keywords trigger CI resource search:
+
+| Keyword | Description |
+|---------|-------------|
+| `artifact` / `artifacts` | Search for build artifacts |
+| `job` / `jobs` | Search for workflow jobs |
+| `workflow` / `workflows` | Search for workflows |
+| `run` / `runs` | Search for workflow runs |
+| `build` | Search CI resources containing "build" |
+| `test` | Search CI resources containing "test" |
+| `deploy` | Search CI resources containing "deploy" |
+| `action` / `actions` | Search for actions |
+
+## CI Examples
+
+| Input | Result |
+|-------|--------|
+| `//link artifact` | Shows all recent artifacts |
+| `//link job` | Shows all recent jobs |
+| `//link build` | Searches CI resources for "build" |
+| `//link test` | Searches CI resources for "test" |
+| `//link deploy` | Searches CI resources for "deploy" |
+
+## Combined URL + CI
+
+When your query contains both a URL and CI keywords, the link preview appears first, followed by CI results:
+
+| Input | Result |
+|-------|--------|
+| `//link cdn.example.com/artifact` | 1. Link preview, 2. CI artifacts |
 
 ## Features
 
@@ -60,17 +87,9 @@ This subcommand requires a GitHub Personal Access Token. See [GitHub API Options
 - **Fuzzy matching**: Search by partial name across job and artifact names
 - **Quick setup**: Click the "GitHub token required" tile to open settings
 
-## Examples
-
-| Input | Output |
-|-------|--------|
-| `//link ci` | Shows all recent CI jobs and artifacts |
-| `//link ci build` | Links to jobs/artifacts containing "build" |
-| `//link ci test-report` | Links to artifacts containing "test-report" |
-
 ## Token Setup
 
-1. Type `//link ci` - if no token is configured, you'll see a setup tile
+1. Type `//link artifact` - if no token is configured, you'll see a setup tile
 2. Click the setup tile to open settings
 3. Paste your GitHub Personal Access Token
 4. Click Save
@@ -87,7 +106,7 @@ The command inserts standard Markdown link syntax:
 ## Privacy
 
 - The GitHub token is stored locally via `chrome.storage.local`
-- When you use `//link ci`, your token is used to fetch workflow data from GitHub's API
+- When you use CI keywords, your token is used to fetch workflow data from GitHub's API
 - Only data from the current repository is fetched
 
 ## Developer notes

--- a/docs/options/github/README.md
+++ b/docs/options/github/README.md
@@ -4,13 +4,14 @@ Shared GitHub API token configuration for commands that require GitHub API acces
 
 ## Features that require a token
 
-- [`//link ci`](../../commands/link/README.md) – Link to CI jobs and artifacts
+- [`//link artifact`](../../commands/link/README.md) – Link to CI artifacts
+- [`//link job`](../../commands/link/README.md) – Link to CI jobs
 
 ## Token Setup
 
 ### Option 1: In picker settings
 
-1. Type `//link ci` or click the settings gear icon in any picker
+1. Type `//link artifact` or click the settings gear icon in any picker
 2. Find the **GitHub Token** section
 3. Paste your Personal Access Token
 4. Click **Save**

--- a/e2e/extension.spec.ts
+++ b/e2e/extension.spec.ts
@@ -2938,11 +2938,11 @@ test.describe("Link Command", () => {
     await browser.close();
   });
 
-  test("//link ci command shows picker", async () => {
+  test("//link artifact command shows picker", async () => {
     const browser = await chromium.launch({ headless: false });
     const { page, textarea } = await setupPage(browser, testServer.port);
 
-    await textarea.fill("//link ci");
+    await textarea.fill("//link artifact");
     await page.waitForTimeout(500);
 
     const picker = page.locator("#slashPalettePicker");
@@ -2952,15 +2952,16 @@ test.describe("Link Command", () => {
     const pickerContent = await picker.textContent();
     // Either shows CI content or token setup message
     expect(
-      pickerContent?.includes("CI") || 
-      pickerContent?.includes("token") || 
-      pickerContent?.includes("GitHub")
+      pickerContent?.includes("CI") ||
+      pickerContent?.includes("token") ||
+      pickerContent?.includes("GitHub") ||
+      pickerContent?.includes("setup")
     ).toBe(true);
 
     await browser.close();
   });
 
-  test("//link ci without token shows setup tile", async () => {
+  test("//link artifact without token shows setup tile", async () => {
     const browser = await chromium.launch({ headless: false });
     const { page, textarea } = await setupPage(browser, testServer.port);
 
@@ -2969,16 +2970,16 @@ test.describe("Link Command", () => {
       localStorage.removeItem("githubApiToken");
     });
 
-    await textarea.fill("//link ci");
+    await textarea.fill("//link artifact");
     await page.waitForTimeout(500);
 
     const picker = page.locator("#slashPalettePicker");
     await expect(picker).toBeVisible({ timeout: 3000 });
 
-    // Should show CI Links title and a tile (setup tile when no token)
+    // Should show CI setup title and a tile (setup tile when no token)
     const pickerContent = await picker.textContent();
-    expect(pickerContent?.includes("CI Links")).toBe(true);
-    
+    expect(pickerContent?.includes("CI setup") || pickerContent?.includes("token")).toBe(true);
+
     // Should have at least one tile button with image
     const tileButtons = picker.locator("button[data-item-index]");
     const tileCount = await tileButtons.count();
@@ -2987,11 +2988,11 @@ test.describe("Link Command", () => {
     await browser.close();
   });
 
-  test("//link ci with search term shows picker", async () => {
+  test("//link build shows picker with CI search", async () => {
     const browser = await chromium.launch({ headless: false });
     const { page, textarea } = await setupPage(browser, testServer.port);
 
-    await textarea.fill("//link ci build");
+    await textarea.fill("//link build");
     await page.waitForTimeout(500);
 
     const picker = page.locator("#slashPalettePicker");
@@ -3004,11 +3005,11 @@ test.describe("Link Command", () => {
     await browser.close();
   });
 
-  test("//link ci picker closes on Escape key", async () => {
+  test("//link job picker closes on Escape key", async () => {
     const browser = await chromium.launch({ headless: false });
     const { page, textarea } = await setupPage(browser, testServer.port);
 
-    await textarea.fill("//link ci");
+    await textarea.fill("//link job");
     await page.waitForTimeout(500);
 
     const picker = page.locator("#slashPalettePicker");
@@ -3024,11 +3025,11 @@ test.describe("Link Command", () => {
     await browser.close();
   });
 
-  test("//link ci shows tile with image", async () => {
+  test("//link artifact shows tile with image", async () => {
     const browser = await chromium.launch({ headless: false });
     const { page, textarea } = await setupPage(browser, testServer.port);
 
-    await textarea.fill("//link ci");
+    await textarea.fill("//link artifact");
     await page.waitForTimeout(500);
 
     const picker = page.locator("#slashPalettePicker");
@@ -3042,7 +3043,7 @@ test.describe("Link Command", () => {
     await browser.close();
   });
 
-  test("//link ci clicking setup tile opens settings panel", async () => {
+  test("//link artifact clicking setup tile opens settings panel", async () => {
     const browser = await chromium.launch({ headless: false });
     const { page, textarea } = await setupPage(browser, testServer.port);
 
@@ -3051,7 +3052,7 @@ test.describe("Link Command", () => {
       localStorage.removeItem("githubApiToken");
     });
 
-    await textarea.fill("//link ci");
+    await textarea.fill("//link artifact");
     await page.waitForTimeout(500);
 
     const picker = page.locator("#slashPalettePicker");

--- a/src/content/commands/link/command.test.ts
+++ b/src/content/commands/link/command.test.ts
@@ -180,8 +180,8 @@ describe("link command", () => {
       expect(linkCommand.noResultsMessage).toContain("/link")
     })
 
-    it("should mention ci option in no results message", () => {
-      expect(linkCommand.noResultsMessage).toContain("ci")
+    it("should mention artifact option in no results message", () => {
+      expect(linkCommand.noResultsMessage).toContain("artifact")
     })
   })
 })

--- a/src/options/github/GitHubOptionsSection.tsx
+++ b/src/options/github/GitHubOptionsSection.tsx
@@ -130,7 +130,10 @@ export function GitHubOptionsSection() {
             A GitHub Personal Access Token enables advanced features:
             <ul className="feature-list">
               <li>
-                <code>/link ci</code> - Link to CI jobs and artifacts
+                <code>/link artifact</code> - Link to CI artifacts
+              </li>
+              <li>
+                <code>/link job</code> - Link to CI jobs
               </li>
             </ul>
             Create a{" "}


### PR DESCRIPTION
Replace the //link ci subcommand with keyword-based CI detection. Users can
now type //link artifact, //link job, //link build, etc. to access CI
features directly without the ci prefix.

Changes:
- Add CI_KEYWORDS constant for triggering CI search (artifact, job, workflow,
  run, build, test, deploy, action)
- Update getResults() to detect CI keywords and combine URL + CI results
- Show link preview first when valid URL is entered, followed by CI results
- Display GitHub token setup tile when CI keywords detected but no token set
- Update all documentation (README, PRIVACY, CLAUDE.md, copilot-instructions)
- Update E2E tests to use new keyword syntax
- Update unit tests for new help message